### PR TITLE
Fix next-day rollover by sending Home Assistant local date to FatSecret API should work

### DIFF
--- a/custom_components/fatsecret/FatSecretCoordinator.py
+++ b/custom_components/fatsecret/FatSecretCoordinator.py
@@ -9,6 +9,7 @@ import aiohttp
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.util import dt as dt_util
 
 from .oauth_helpers import (
     oauth_build_authorization_header,
@@ -82,8 +83,12 @@ class FatSecretCoordinator(DataUpdateCoordinator):
         Returns a dict with all fields in FATSECRET_FIELDS as keys and their summed
         values as floats.
         """
-
-        query_params = {"format": "json"}  # API params
+        local_today = dt_util.now().date().isoformat()
+        
+        query_params = {
+            "format": "json",
+            "date": local_today,                           
+        }  # API params
 
         oauth_params = {
             OAUTH_PARAM_CONSUMER_KEY: self.entry.data[CONF_CONSUMER_KEY],


### PR DESCRIPTION
This PR fixes an issue where the integration begins returning entries for the next calendar day in the evening (around ~6 PM CDT).

The cause is that the integration currently calls the FatSecret API without specifying a date, which causes the API to return entries for the server's "current day" rather than the user's Home Assistant local day.

Root Cause

The integration currently builds the query as:

query_params = {"format": "json"}

According to the FatSecret API documentation:

If no date is supplied, the API returns entries for the current day.

Because the API determines "current day" using its own timezone, users in western timezones can see their "current day" switch early in the evening.

Fix

This PR explicitly sends the Home Assistant local date with each request:

local_today = dt_util.now().date().isoformat()

query_params = {
    "format": "json",
    "date": local_today,
}

This ensures the integration always requests entries for the correct local day.

Result

Prevents next-day rollover in the evening

Makes API behavior deterministic

Aligns the integration with Home Assistant timezone handling